### PR TITLE
Allow overriding hostnames via ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ scrape_configs:
       - targets: ['nodeip:8000']
 ```
 
+# Overriding hostnames
+
+If you are running the full node on a different host or container, you can override the hostnames used for connecting to the daemons by setting one or all of the following environment variables: `FULL_NODE_HOST`, `WALLET_HOST`, `HARVESTER_HOST`, `FARMER_HOST`. All hostnames default to localhost.
+
 # Donation
 If you like this work and it helps you to monitor your farm please consider donating XCH to `xch1z026zx5a7xask0srznwnv9ktllc96flvcsk9ly7k06dhnje0asfsym8xuc`
 It will be really appreciated and help me keeping this exporter working

--- a/prometheus-chia-exporter/chia-exporter.py
+++ b/prometheus-chia-exporter/chia-exporter.py
@@ -1,6 +1,7 @@
 from prometheus_client import start_http_server, Gauge, Enum, Info
 import asyncio
 import time
+import os
 from chia.rpc.wallet_rpc_api import WalletRpcApi
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
@@ -10,8 +11,6 @@ from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.cmds.netspace_funcs import netstorge_async as w
 from chia.cmds.farm_funcs import get_average_block_time
-
-self_hostname="localhost"
 
 net_config={"daemon_ssl":{"private_crt":"","private_key":""}}
 
@@ -31,14 +30,19 @@ REWARD_ADDRESS = Info('chia_reward_address', 'Farming rewards go to this address
 async def main():
     try:
         config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+        rpc_host = os.getenv("FULL_NODE_HOST", "localhost")
         rpc_port = config["full_node"]["rpc_port"]
+        wallet_host = os.getenv("WALLET_HOST", "localhost")
         wallet_rpc_port = config["wallet"]["rpc_port"]
+        harvester_host = os.getenv("HARVESTER_HOST", "localhost")
         harvester_rpc_port = config["harvester"]["rpc_port"]
+        farmer_host = os.getenv("FARMER_HOST", "localhost")
         farmer_rpc_port = config["farmer"]["rpc_port"]
-        client = await WalletRpcClient.create(self_hostname, wallet_rpc_port,DEFAULT_ROOT_PATH,config)
-        client_node = await FullNodeRpcClient.create(self_hostname, rpc_port,DEFAULT_ROOT_PATH,config)
-        client_harvester = await HarvesterRpcClient.create(self_hostname, harvester_rpc_port,DEFAULT_ROOT_PATH,config)
-        client_farmer = await FarmerRpcClient.create(self_hostname, farmer_rpc_port,DEFAULT_ROOT_PATH,config)
+
+        client = await WalletRpcClient.create(wallet_host, wallet_rpc_port,DEFAULT_ROOT_PATH,config)
+        client_node = await FullNodeRpcClient.create(rpc_host, rpc_port,DEFAULT_ROOT_PATH,config)
+        client_harvester = await HarvesterRpcClient.create(harvester_host, harvester_rpc_port,DEFAULT_ROOT_PATH,config)
+        client_farmer = await FarmerRpcClient.create(farmer_host, farmer_rpc_port,DEFAULT_ROOT_PATH,config)
 
         # blockchain stuff
         blockchain = await client_node.get_blockchain_state()


### PR DESCRIPTION
Hey, thanks for creating this! I'm running chia in a docker container and would like to run this in a separate container, so I modified the code a bit to allow overriding the default hostname to something set by the environment. A quick test showed that this would work by using something like this, for example:

```
docker run --rm \
  --network chia-node_chia-node \
  -e FULL_NODE_HOST=chia \
  -e WALLET_HOST=chia \
  -e HARVESTER_HOST=chia \
  -e FARMER_HOST=chia \
  -v <somewhere>/chia/home/:/root/.chia/:ro \
  -p 12345:8000 \
  strayer/chia-exporter-test
```

I didn't add any environment for the RPC ports, since the config will need to be included anyway for the certificates and whatever else the Python chia library needs.